### PR TITLE
Sign extension causes "messed up" hexdump output, declare sbuf as unsigned char

### DIFF
--- a/shmcat.c
+++ b/shmcat.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
         printf("shmat() failed: %s\n", strerror(errno));
         return -1;
     }
-    char sbuf[32];
+    unsigned char sbuf[32];
     memset(sbuf, 0, sizeof sbuf);
     size_t si = 0;
     printf("\n%8.8zX  ", si);


### PR DESCRIPTION
The hexdump code uses a signed char for printing the ASCII hex version of the bytes in the shmem segment. On (at least) the following, this causes problems with the hexdump output, which uses `%2.2x`, which doesn't work correctly with signed bytes:

 * gcc >= 6 (glibc, x86 and x86_64 builds running on an x86_64 system)
 * clang >= 7 (glibc, x86 and x86_64 builds running on an x86_64 system)
  * gcc >= 9 (musl libc, x86 and x86_64 builds running on an x86_64 system)

The `printf()` disregards the precision specifier and outputs the sign extended form of the byte when the high-bit is set, which makes the hexdump output really ugly. Example:

```
003E860  FFFFFFCF 74 19 FFFFFFFF FFFFFFD9 71 0D FFFFFFFF FFFFFFD9 71 0D FFFFFFFF FFFFFFCF 74 19 FFFFFFFF  .t...q...q...t..
```

Setting `sbuf` as `unsigned char` fixes it and seems like a nicer solution than casting the argument to printf, e.g. `printf("%2.2x", (unsigned char)sbuf[sis])`

Thanks for the neat tool, it's a big timesaver since I only have to read shmem segments every once in a blue moon and always lose whatever crappy stub I wrote up to do it the last time :)

I don't know if you maintain this or not, feel free to do whatever you like with this PR. I just figured I might as well send it over to save you or anyone who may stumble across it the hassle

EDIT, forgot to include the "fixed" output, though I'm sure you know what it looks like-

```
0003E860   CF  74  19  FF  D9  71  0D  FF  D9  71  0D  FF  CF  74  19  FF  .t...q...q...t..
```